### PR TITLE
Fix broken Link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ If you have any specific questions, please reach out to us.
 
 #Integration
 
-For Integration instructions please visit our developer hub Android SDK page and [developer.sensorberg.com/android-sdk](https://developer.sensorberg.com/android-sdk)
+For Integration instructions please visit our developer hub Android SDK page and [developer.sensorberg.com/android](https://developer.sensorberg.com/android)
 
 #Build,Test,Deploy
 


### PR DESCRIPTION
https://developer.sensorberg.com/android-sdk leads to a 404 page, update with https://developer.sensorberg.com/android