### PR TITLE
Fix sharedpreferences multiprocess

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "android-sdk/lib/multiprocess-preferences"]
+	path = android-sdk/lib/multiprocess-preferences
+	url = git@github.com:gelldur/multiprocess-preferences.git

--- a/android-sdk/build.gradle
+++ b/android-sdk/build.gradle
@@ -87,6 +87,9 @@ android {
         exclude 'LICENSE'
         exclude 'META-INF/services/javax.annotation.processing.Processor'
     }
+    sourceSets {
+        main.java.srcDirs += 'lib/multiprocess-preferences/library/src/main/java'
+    }
 
     compileOptions {
         encoding "UTF-8"

--- a/android-sdk/src/androidTest/java/com/sensorberg/SensorbergSdkTests.java
+++ b/android-sdk/src/androidTest/java/com/sensorberg/SensorbergSdkTests.java
@@ -2,6 +2,7 @@ package com.sensorberg;
 
 import com.sensorberg.sdk.resolver.BeaconEvent;
 
+import com.gdubina.multiprocesspreferences.MultiprocessPreferenceManager;
 import org.fest.assertions.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
@@ -37,6 +38,7 @@ public class SensorbergSdkTests {
             @Override
             public void run() {
                 tested = Mockito.spy(new SensorbergSdk(InstrumentationRegistry.getContext(), TestConstants.API_TOKEN_DEFAULT));
+                MultiprocessPreferenceManager.getDefaultSharedPreferences(InstrumentationRegistry.getContext());
             }
         });
         SensorbergSdk.listeners.clear();

--- a/android-sdk/src/main/AndroidManifest.xml
+++ b/android-sdk/src/main/AndroidManifest.xml
@@ -76,5 +76,12 @@
             </intent-filter>
         </receiver>
 
+        <provider
+                android:name="com.gdubina.multiprocesspreferences.PreferencesProvider"
+                android:authorities="${applicationId}.PreferenceProvider"
+                android:exported="false"
+                android:multiprocess="false"
+                android:enabled="true"/>
+
     </application>
 </manifest>

--- a/android-sdk/src/main/java/com/sensorberg/di/ProvidersModule.java
+++ b/android-sdk/src/main/java/com/sensorberg/di/ProvidersModule.java
@@ -8,6 +8,7 @@ import android.content.SharedPreferences;
 import android.location.LocationManager;
 import android.support.annotation.Nullable;
 
+import com.gdubina.multiprocesspreferences.MultiprocessPreferenceManager;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.sensorberg.sdk.internal.AndroidBluetoothPlatform;
@@ -66,7 +67,7 @@ public class ProvidersModule {
     @Provides
     @Singleton
     public SharedPreferences provideSettingsSharedPrefs(Context context) {
-        return context.getSharedPreferences(SENSORBERG_PREFERENCE_IDENTIFIER, Context.MODE_PRIVATE);
+        return MultiprocessPreferenceManager.getDefaultSharedPreferences(context);
     }
 
     @Provides


### PR DESCRIPTION
SharedPreferences should not be accessed in multiprocess enviroment.

From [documentation](https://developer.android.com/reference/android/content/SharedPreferences.html):
> Note: This class does not support use across multiple processes.


In code documentation:

```
* @deprecated MODE_MULTI_PROCESS does not work reliably in
* some versions of Android, and furthermore does not provide any
* mechanism for reconciling concurrent modifications across
* processes.  Applications should not attempt to use it.  Instead,
* they should use an explicit cross-process data management
* approach such as {@link android.content.ContentProvider
ContentProvider}.
*/
@Deprecated
public static final int MODE_MULTI_PROCESS = 0x0004;
```